### PR TITLE
Part: rename to uppercase, Part_ProjectionOnSurface

### DIFF
--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2424,18 +2424,18 @@ bool CmdBoxSelection::isActive(void)
 }
 
 //===========================================================================
-// Part_projectionOnSurface
+// Part_ProjectionOnSurface
 //===========================================================================
 DEF_STD_CMD_A(CmdPartProjectionOnSurface)
 
 CmdPartProjectionOnSurface::CmdPartProjectionOnSurface()
-  :Command("Part_projectionOnSurface")
+  :Command("Part_ProjectionOnSurface")
 {
   sAppModule = "Part";
   sGroup = QT_TR_NOOP("Part");
   sMenuText = QT_TR_NOOP("Create projection on surface...");
   sToolTipText = QT_TR_NOOP("Create projection on surface...");
-  sWhatsThis = "Part_projectionOnSurface";
+  sWhatsThis = "Part_ProjectionOnSurface";
   sStatusTip = sToolTipText;
   sPixmap = "Part_ProjectionOnSurface";
 }

--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -141,7 +141,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Part_Offset"
           << "Part_Offset2D"
           << "Part_Thickness"
-          << "Part_projectionOnSurface"
+          << "Part_ProjectionOnSurface"
           << "Separator"
           << "Part_EditAttachment";
 
@@ -198,7 +198,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
           << "Part_Sweep"
           << "Part_CompOffset"
           << "Part_Thickness"
-          << "Part_projectionOnSurface";
+          << "Part_ProjectionOnSurface";
 
     Gui::ToolBarItem* boolop = new Gui::ToolBarItem(root);
     boolop->setCommand("Boolean");


### PR DESCRIPTION
For consistency with all other commands that start with capital letter, `Part_ProjectionOnSurface`, not `Part_projectionOnSurface`.